### PR TITLE
Fix $apply and change binding for switch-active

### DIFF
--- a/src/bsSwitch.js
+++ b/src/bsSwitch.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('frapontillo.bootstrap-switch', [])
-  .directive('bsSwitch', function ($timeout) {
+  .directive('bsSwitch', function ($timeout, $rootScope) {
     return {
       template:
         '<div class="make-switch" data-on-label="{{switchOnLabel}}" data-off-label="{{switchOffLabel}}" ' +
@@ -101,6 +101,10 @@ angular.module('frapontillo.bootstrap-switch', [])
           element.on('switch-change', function (e, data) {
             var value = data.value;
             scope.ngModel = value;
+            if (!(scope.$$phase || $rootScope.$$phase))
+            {
+              scope.$apply();
+            }
           });
         };
 


### PR DESCRIPTION
Updated the binding type for switch-active, and remove the check (var || true).
Also put back the $apply, but he is only triggering when you are not inside a digest cycle.
