### PR TITLE
use controller.$viewValue (boolean) instead of $modelValue (anything) an...

### DIFF
--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -19,27 +19,17 @@ angular.module('frapontillo.bootstrap-switch')
         switchRadioOff: '@'
       },
       link: function link(scope, element, attrs, controller) {
-        /**
-         * Return the true value for this specific checkbox.
-         * @returns {Object} representing the true view value; if undefined, returns true.
-         */
-        var getTrueValue = function() {
-          var trueValue = attrs.ngTrueValue;
-          if (!angular.isString(trueValue)) {
-            trueValue = true;
-          }
-          return trueValue;
-        };
 
         /**
          * Listen to model changes.
          */
         var listenToModel = function () {
           // When the model changes
-          controller.$formatters.push(function (newValue) {
+          controller.$viewChangeListeners.push(function () {
+            var newValue = controller.$viewValue;
             if (newValue !== undefined) {
               $timeout(function () {
-                element.bootstrapSwitch('state', (newValue === getTrueValue()), true);
+                element.bootstrapSwitch('state', newValue || false, true);
               });
             }
           });
@@ -125,11 +115,9 @@ angular.module('frapontillo.bootstrap-switch')
         // Wrap in a $timeout to give the ngModelController
         // enough time to resolve the $modelValue
         $timeout(function () {
-          var isInitiallyActive = controller.$modelValue === getTrueValue();
-
           // Bootstrap the switch plugin
           element.bootstrapSwitch({
-            state: isInitiallyActive
+            state: controller.$viewValue
           });
 
           // Listen and respond to model changes
@@ -137,9 +125,6 @@ angular.module('frapontillo.bootstrap-switch')
 
           // Listen and respond to view changes
           listenToView();
-
-          // Set the initial view value (may differ from the model value)
-          controller.$setViewValue(isInitiallyActive);
 
           // On destroy, collect ya garbage
           scope.$on('$destroy', function () {


### PR DESCRIPTION
Hi, thanks for writing this. It's a very clean wrapper. I found it didn't work out of the box, though (especially the version in bower). Here are a few minor changes I made that simplify the directive and fix a small refresh bug:
1. instead of computing the true value using attrs.ngTrueValue and comparing that against the model, just use controller.$viewValue. The input already does this calculation, so why not take advantage of it?
2. instead of using $formatters to update the switch, use $viewChangeListeners. This fixed a refresh problem I was having.
3. pass the $viewValue as the initial state. It just works.

cheers,
-Mark
