### PR TITLE
Handle ngModelOptions

### DIFF
--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -149,8 +149,12 @@ angular.module('frapontillo.bootstrap-switch')
             }
           });
 
+          function modelValue() {
+            return controller.$modelValue;
+          }
+
           // When the model changes
-          scope.$watch(attrs.ngModel, function(newValue) {
+          scope.$watch(modelValue, function(newValue) {
             initMaybe();
             if (newValue !== undefined) {
               element.bootstrapSwitch('state', newValue === getTrueValue(), true);

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -75,6 +75,10 @@ describe('Directive: bsSwitch', function () {
     'inverse': {
       scope: {model:true},
       element: 'ng-model="model" type="checkbox" switch-inverse="{{ inverse }}"'
+    },
+    'getterSetter': {
+      scope: {},
+      element: 'ng-model="modelGetterSetter" ng-model-options="{getterSetter: true}" type="checkbox"'
     }
   };
 
@@ -513,5 +517,28 @@ describe('Directive: bsSwitch', function () {
   }
   it('should invert the on and off switches and then reset them', inject(makeTestInverse()));
   it('should invert the on and off switches and then reset them (input)', inject(makeTestInverse(true)));
+
+  // Test the getterSetter ng-model option
+  function makeTestGetterSetter(input) {
+    return function () {
+      var element = compileDirective('getterSetter', input);
+      var localValue = false;
+
+      scope.modelGetterSetter = function() {
+        return localValue;
+      };
+      scope.$apply();
+
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+
+      localValue = true;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+    };
+  }
+  it('should watch updates in getterSetter', inject(makeTestGetterSetter()));
+  it('should watch updates in getterSetter', inject(makeTestGetterSetter(true)));
 
 });


### PR DESCRIPTION
As of Angular 1.3, it's possible to use jQuery style getter/setter functions in ngModel in addition to just mutating a field. You can do that by adding [ng-model-options][1]:

```html
<input ng-model="foo" ng-model-options="{getterSetter: true}">
```

where `foo` is a function that can be invoked with either 0 parameters (then it acts as a getter), or 1 parameter (then it acts as a setter).

Because of this, $watching on attrs.ngModel is no longer sufficient. You need to $watch the actual $modelValue on ngModel controller.

In addition to the fix for the aforementioned issue, I also added missing dependencies needed to run tests to the package.json file.

[1]: https://docs.angularjs.org/api/ng/directive/ngModelOptions