### PR TITLE
make work empty states

### DIFF
--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -93,7 +93,13 @@ angular.module('frapontillo.bootstrap-switch')
             },
             'switchInverse': getBooleanFromString,
             'switchReadonly': getBooleanFromString,
-            'switchChange': getExprFromString
+            'switchChange': getExprFromString,
+            'switchOffText': function (value) {
+              return (value && value.length === 0) ? '' : value;
+            },
+            'switchOnText': function (value) {
+              return (value && value.length === 0) ? '' : value;
+            }
           };
           var transFn = map[attrName] || getValueOrUndefined;
           return transFn(attrs[attrName]);


### PR DESCRIPTION
When using 
switch-on-text=""
switch-off-text=""
Switch is empty

Other behavior by default

- without this attrs as before: on/off
- with "" - empty
- with "info" - info