### PR TITLE
Fix Indeterminate State not Triggered from 'false' state

### DIFF
--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -151,7 +151,7 @@ angular.module('frapontillo.bootstrap-switch')
             } else {
               controller.$setViewValue(viewValue);
               controller.$formatters[0] = function(value) {
-                if (value === undefined) {
+                if (value === undefined || value === null) {
                   return value;
                 }
                 return angular.equals(value, getTrueValue());

--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -155,7 +155,7 @@ angular.module('frapontillo.bootstrap-switch')
                   return value;
                 }
                 return angular.equals(value, getTrueValue());
-              }
+              };
             }
           }
         };

--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -150,6 +150,12 @@ angular.module('frapontillo.bootstrap-switch')
               controller.$setViewValue(controller.$modelValue);
             } else {
               controller.$setViewValue(viewValue);
+              controller.$formatters[0] = function(value) {
+                if (value === undefined) {
+                  return value;
+                }
+                return angular.equals(value, getTrueValue());
+              }
             }
           }
         };

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -723,4 +723,140 @@ describe('Directive: bsSwitch', function () {
   }
   it('should evaluate change expression when model changes', inject(makeTestModelSwitchChange()));
   it('should evaluate change expression when model changes', inject(makeTestModelSwitchChange(true)));
+
+  // Test the null model from true state
+  function makeTestToIndeterminateNullFromTrue(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = true;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      scope.model = null;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+    };
+  }
+  it('should change from true to the indeterminate state when the model is null', inject(makeTestToIndeterminateNullFromTrue()));
+  it('should change from true to the indeterminate state when the model is null (input)', inject(makeTestToIndeterminateNullFromTrue(true)));
+
+  // Test the null model from false state
+  function makeTestToIndeterminateNullFromFalse(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = false;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      scope.model = null;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+    };
+  }
+  it('should change from false to the indeterminate state when the model is null', inject(makeTestToIndeterminateNullFromFalse()));
+  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestToIndeterminateNullFromFalse(true)));
+
+  // Test the undefined model from true state
+  function makeTestToIndeterminateUndefinedFromTrue(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = true;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      scope.model = undefined;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+    };
+  }
+  it('should change from true to the indeterminate state when the model is null', inject(makeTestToIndeterminateUndefinedFromTrue()));
+  it('should change from true to the indeterminate state when the model is null (input)', inject(makeTestToIndeterminateUndefinedFromTrue(true)));
+
+  // Test the undefined model from false state
+  function makeTestToIndeterminateUndefinedFromFalse(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = false;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      scope.model = undefined;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+    };
+  }
+  it('should change from false to the indeterminate state when the model is null', inject(makeTestToIndeterminateUndefinedFromFalse()));
+  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestToIndeterminateUndefinedFromFalse(true)));
+
+  // Test the changing multiple state
+  function makeTestMultipleChangeOfStateIndeterminate(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = false;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      scope.model = undefined;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      scope.model = true;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+    };
+  }
+  it('should change from false to the indeterminate state when the model is null', inject(makeTestMultipleChangeOfStateIndeterminate()));
+  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestMultipleChangeOfStateIndeterminate(true)));
+
+  // Test the changing multiple state other way round
+  function makeTestMultipleChangeOfStateIndeterminateReverse(input) {
+    return function () {
+      var element = compileDirective(undefined, input);
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = true;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+      scope.model = undefined;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      scope.model = false;
+      scope.$apply();
+      expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+    };
+  }
+  it('should change from false to the indeterminate state when the model is null', inject(makeTestMultipleChangeOfStateIndeterminate()));
+  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestMultipleChangeOfStateIndeterminate(true)));
 });

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -831,8 +831,8 @@ describe('Directive: bsSwitch', function () {
       expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
     };
   }
-  it('should change from false to the indeterminate state when the model is null', inject(makeTestMultipleChangeOfStateIndeterminate()));
-  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestMultipleChangeOfStateIndeterminate(true)));
+  it('should change from false to the indeterminate state and to true', inject(makeTestMultipleChangeOfStateIndeterminate()));
+  it('should change from false to the indeterminate state and to true (input)', inject(makeTestMultipleChangeOfStateIndeterminate(true)));
 
   // Test the changing multiple state other way round
   function makeTestMultipleChangeOfStateIndeterminateReverse(input) {
@@ -848,8 +848,8 @@ describe('Directive: bsSwitch', function () {
       scope.model = undefined;
       scope.$apply();
       expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeTruthy();
-      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
-      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
       scope.model = false;
       scope.$apply();
       expect(element.hasClass(CONST.SWITCH_INDETERMINATE_CLASS)).toBeFalsy();
@@ -857,6 +857,6 @@ describe('Directive: bsSwitch', function () {
       expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
     };
   }
-  it('should change from false to the indeterminate state when the model is null', inject(makeTestMultipleChangeOfStateIndeterminate()));
-  it('should change from false to the indeterminate state when the model is null (input)', inject(makeTestMultipleChangeOfStateIndeterminate(true)));
+  it('should change from false to the indeterminate state and to false', inject(makeTestMultipleChangeOfStateIndeterminateReverse()));
+  it('should change from false to the indeterminate state and to false (input)', inject(makeTestMultipleChangeOfStateIndeterminateReverse(true)));
 });


### PR DESCRIPTION
#76

Hi, after tracing the calls of indeterminate toggling I've found the source of this minor bug.
The problems happens with the default checkbox $formatters by angular.
#### The default checkbox formatters[0] on **angular.js:24100**

``` javascript
ctrl.$formatters.push(function(value) {
  return equals(value, trueValue);
});
```

So I did a quick hack to replace the default formatters in **initMaybe** @ **bsSwitch.js**
#### bsSwitch.js:153

``` javascript
controller.$formatters[0] = function(value) {
  if (value === undefined) {
    return value;
  }
  return angular.equals(value, getTrueValue());
}
```
