### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ angular-bootstrap-switch
 
 AngularJS directive for the [bootstrap-switch](https://github.com/nostalgiaz/bootstrap-switch) jQuery plugin.
 
-##Usage
+## Usage
 
-###Installation
+### Installation
 ```shell
 $ bower install angular-bootstrap-switch
 ```
@@ -23,7 +23,7 @@ $ npm install angular-bootstrap-switch
 
 This will install AngularJS, jQuery, and the original bootstrap-switch.
 
-###Registration
+### Registration
 
 To be able to use the directive, you need to register the `angular-bootstrap-switch` module as a dependency:
 
@@ -33,7 +33,7 @@ angular.module('yourModule', ['frapontillo.bootstrap-switch'
 ]);
 ```
 
-###Directive
+### Directive
 The directive can work on both element and attribute levels. The following example contains all of the supported attributes:
 
 ```html
@@ -84,21 +84,21 @@ meaning you have to specify the same `ngModel` and a different `value` or `ng-va
 * `switch-inverse`, inverts the on/off handles
 * `switch-change`, evaluates an expression whenever the model value changes. Instead, `ng-change` will fire when view value changes (e.g from a click)
 
-###Migrating from bootstrap-switch~2
+### Migrating from bootstrap-switch~2
 
 Read the [CHANGELOG](CHANGELOG.md#030-alpha1-2014-02-22) information to learn what's different in `0.3.0`.
 
-###Examples
+### Examples
 
 The `example` folder shows a simple working demo of the switch.
 
-###Compatibility
+### Compatibility
 
 IE8 requires you to attach the directive to an `<input type="checkbox">` or `<input type="radio">`. Due to some incompatibilities it is not possible to use a custom tag or `div` instead.
 
-##Development
+## Development
 
-###Test and build
+### Test and build
 
 To build the directive yourself you need to have NodeJS. Then do the following:
 
@@ -110,15 +110,15 @@ $ grunt test-travis
 $ grunt build
 ```
 
-###Contribute
+### Contribute
 
 To contribute, please follow the generic [AngularJS Contributing Guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md), with the only exception to send the PR to the `develop` branch instead of `master`.
 
-##Author
+## Author
 
 Francesco Pontillo (<mailto:francescopontillo@gmail.com>)
 
-##License
+## License
 
 ```
    Copyright 2014-2015-2016 Francesco Pontillo


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
