### PR TITLE
Update view on model change when switch is disabled

### DIFF
--- a/src/directives/bsSwitch.js
+++ b/src/directives/bsSwitch.js
@@ -182,6 +182,12 @@ angular.module('frapontillo.bootstrap-switch')
           // When the model changes
           controller.$render = function () {
             initMaybe();
+
+            // WORKAROUND for https://github.com/Bttstrp/bootstrap-switch/issues/540
+            // to update model value when bootstrapSwitch is disabled we should
+            // re-enable it and only then update 'state'
+            element.bootstrapSwitch('disabled', '');
+
             var newValue = controller.$modelValue;
             if (newValue !== undefined && newValue !== null) {
               element.bootstrapSwitch('state', newValue === getTrueValue(), true);
@@ -189,6 +195,10 @@ angular.module('frapontillo.bootstrap-switch')
               element.bootstrapSwitch('indeterminate', true, true);
               controller.$setViewValue(undefined);
             }
+
+            // return initial value for "disabled"
+            setActive();
+
             switchChange();
           };
 

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -391,7 +391,7 @@ describe('Directive: bsSwitch', function () {
   it('should change the model, then deactivate the switch', inject(makeTestChangeModelThenDeactivate()));
   it('should change the model, deactivate the switch (input)', inject(makeTestChangeModelThenDeactivate(true)));
 
-   // Test a model change when switch is deactivated
+  // Test a model change when switch is deactivated
   function makeTestChangeModelWhenSwitchIsDeactivated() {
     return function () {
       var element = compileDirective('active');

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -391,6 +391,34 @@ describe('Directive: bsSwitch', function () {
   it('should change the model, then deactivate the switch', inject(makeTestChangeModelThenDeactivate()));
   it('should change the model, deactivate the switch (input)', inject(makeTestChangeModelThenDeactivate(true)));
 
+   // Test a model change when switch is deactivated
+  function makeTestChangeModelWhenSwitchIsDeactivated() {
+    return function () {
+      var element = compileDirective('active');
+      scope.model = false;
+      scope.isActive = false;
+      scope.$apply();
+      $timeout.flush();
+      // test the active state, should be false
+      expect(element.hasClass(CONST.SWITCH_DISABLED_CLASS)).toBeTruthy();
+      expect(element.find(CONST.INPUT_SELECTOR).attr('disabled')).toBeTruthy();
+      // test the model, should be false
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
+
+	  scope.model = true;
+	  scope.$apply();
+
+	  // test the active state, should be false
+      expect(element.hasClass(CONST.SWITCH_DISABLED_CLASS)).toBeTruthy();
+      expect(element.find(CONST.INPUT_SELECTOR).attr('disabled')).toBeTruthy();
+	  // test the model, should be true
+      expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
+      expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
+    };
+  }
+  it('should deactivate the switch, then change the model', inject(makeTestChangeModelWhenSwitchIsDeactivated()));
+
   // Test the activation
   function makeTestActivate(input) {
     return function () {

--- a/test/spec/directives/bsSwitchSpec.js
+++ b/test/spec/directives/bsSwitchSpec.js
@@ -406,13 +406,13 @@ describe('Directive: bsSwitch', function () {
       expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeTruthy();
       expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeFalsy();
 
-	  scope.model = true;
-	  scope.$apply();
+      scope.model = true;
+      scope.$apply();
 
-	  // test the active state, should be false
+      // test the active state, should be false
       expect(element.hasClass(CONST.SWITCH_DISABLED_CLASS)).toBeTruthy();
       expect(element.find(CONST.INPUT_SELECTOR).attr('disabled')).toBeTruthy();
-	  // test the model, should be true
+      // test the model, should be true
       expect(element.hasClass(CONST.SWITCH_OFF_CLASS)).toBeFalsy();
       expect(element.hasClass(CONST.SWITCH_ON_CLASS)).toBeTruthy();
     };


### PR DESCRIPTION
Workaround for https://github.com/Bttstrp/bootstrap-switch/issues/540

For a year owner does not fix the problem of updating model value when the switch is disabled and even open pull request did not help. But this functional is important so I added workround that will not break anything if this problem will be fixed in linked module. But when will this happen? It seems that this repository is no longer being active supported.

Also resolve issue #132
